### PR TITLE
Fix pruned tensor shape comments

### DIFF
--- a/ASR/zipformer/model.py
+++ b/ASR/zipformer/model.py
@@ -263,8 +263,8 @@ class AsrModel(nn.Module):
             s_range=prune_range,
         )
 
-        # am_pruned : [B, T, prune_range, encoder_dim]
-        # lm_pruned : [B, T, prune_range, decoder_dim]
+        # am_pruned : [B, T, prune_range, joiner_dim]
+        # lm_pruned : [B, T, prune_range, joiner_dim]
         am_pruned, lm_pruned = k2.do_rnnt_pruning(
             am=self.joiner.encoder_proj(encoder_out),
             lm=self.joiner.decoder_proj(decoder_out),


### PR DESCRIPTION
## Summary
- correct the `am_pruned` and `lm_pruned` tensor shape comments to use `joiner_dim`

## Why
- both tensors are projected through the joiner before pruning, so `encoder_dim` and `decoder_dim` are misleading here

## Impact
- documentation/comment accuracy only
- no runtime behavior changes
